### PR TITLE
numpy/astropy deprecation warnings

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install 'scipy${{ matrix.scipy-version }}'
           python -m pip install matplotlib
           python -m pip install pyyaml 
-      
+	  python -m pip install pytest_astropy_header      
       - name: Run the test
         run: pytest
           

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install 'scipy${{ matrix.scipy-version }}'
           python -m pip install matplotlib
           python -m pip install pyyaml 
-	  python -m pip install pytest_astropy_header      
+          python -m pip install pytest_astropy_header
       - name: Run the test
         run: pytest
           

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -71,7 +71,7 @@ jobs:
         
         - name: Install Python dependencies
           run: |
-            python -m pip install --upgrade pip wheel Sphinx
+            python -m pip install --upgrade pip wheel docutils\<0.18 Sphinx
             python -m pip install sphinx-astropy
             python -m pip install speclite
         

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,3 +20,4 @@ Operations with Filters
 
 .. automodapi:: speclite.filters
     :no-inheritance-diagram:
+    :skip: get_path_of_data_file

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,4 +20,3 @@ Operations with Filters
 
 .. automodapi:: speclite.filters
     :no-inheritance-diagram:
-    :skip: get_path_of_data_file

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ license = BSD
 url = http://speclite.readthedocs.io/
 edit_on_github = True
 github_project = dkirkby/speclite
-install_requires = astropy scipy pyyaml
+install_requires = astropy scipy pyyaml pytest_astropy_header
 # version should be PEP440 compatible, e.g. 0.8 or 0.8dev (http://www.python.org/dev/peps/pep-0440)
 version = 0.15dev
 

--- a/speclite/conftest.py
+++ b/speclite/conftest.py
@@ -12,7 +12,7 @@ else:
     # automatically made available when Astropy is installed. This means it's
     # not necessary to import them here, but we still need to import global
     # variables that are used for configuration.
-    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
 from astropy.tests.helper import enable_deprecations_as_exceptions
 

--- a/speclite/filters.py
+++ b/speclite/filters.py
@@ -829,7 +829,7 @@ class FilterResponse(object):
         response = self.interpolator(wavelength)
         # If the input was scalar, return a scalar.
         if response.shape == ():
-            response = np.asscalar(response)
+            response = response.item()
         return response
 
 

--- a/speclite/redshift.py
+++ b/speclite/redshift.py
@@ -108,11 +108,11 @@ def redshift(z_in, z_out, data_in=None, data_out=None, rules=[]):
     """
 
     if not isinstance(z_in, np.ndarray):
-        z_in = np.float(z_in)
+        z_in = float(z_in)
     if np.any(z_in <= -1):
         raise ValueError('Found invalid z_in <= -1.')
     if not isinstance(z_out, np.ndarray):
-        z_out = np.float(z_out)
+        z_out = float(z_out)
     if np.any(z_out <= -1):
         raise ValueError('Found invalid z_out <= -1.')
     z_factor = (1.0 + z_out) / (1.0 + z_in)
@@ -136,7 +136,7 @@ def redshift(z_in, z_out, data_in=None, data_out=None, rules=[]):
         if not isinstance(name, str):
             raise ValueError('Invalid name in rule: {0}'.format(name))
         try:
-            exponent = np.float(rule.get('exponent'))
+            exponent = float(rule.get('exponent'))
         except TypeError:
             raise ValueError(
                 'Invalid exponent for {0}: {1}.'
@@ -197,7 +197,7 @@ def redshift(z_in, z_out, data_in=None, data_out=None, rules=[]):
 
     for rule in rules:
         name = rule.get('name')
-        exponent = np.float(rule.get('exponent'))
+        exponent = float(rule.get('exponent'))
         array_in = rule.get('array_in')
         data_out[name][:] = array_in * z_factor**exponent
         if data_in is None and ma.isMA(array_in):

--- a/speclite/utils/package_data.py
+++ b/speclite/utils/package_data.py
@@ -5,6 +5,8 @@ import pkg_resources
 # TODO: should make these Path objects
 
 def get_path_of_data_file(data_file) -> str:
+    """convenience wrapper to return location of data file
+    """
     file_path = pkg_resources.resource_filename(
         "speclite", os.path.join("data", f"{data_file}"))
 
@@ -12,6 +14,8 @@ def get_path_of_data_file(data_file) -> str:
 
 
 def get_path_of_data_dir() -> str:
+    """convenience wrapper to return location of data directory
+    """
     file_path = pkg_resources.resource_filename("speclite", "data")
 
     return file_path


### PR DESCRIPTION
Fixes #71 by addressing deprecation warnings for astropy 4.3.1 and numpy 1.21.2 while maintaining compatibility with astropy 4.0.1.post1 and numpy 1.19.1 on Cori. 

Installation of `pytest_astropy_header` in `python-package.yml` has been added in order for github workflow unit tests to function properly.

Please review and merge / comment as appropriate. 