### PR TITLE
add speclite.benchmark and speclite.utils to api document

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,3 +21,9 @@ Operations with Filters
 .. automodapi:: speclite.filters
     :no-inheritance-diagram:
     :skip: get_path_of_data_file
+
+Other Functions
+===============
+
+.. automodapi:: speclite.benchmark
+.. automodapi:: speclite.utils


### PR DESCRIPTION
This change includes `speclite.utils`, which contains `get_path_of_data_file()`, as well as `speclite.benchmark`, in the API documentation.