### PR TITLE
pkg_resources is deprecated, using new interfaces

### DIFF
--- a/speclite/resample.py
+++ b/speclite/resample.py
@@ -6,9 +6,9 @@ from __future__ import print_function, division
 import numpy as np
 import numpy.ma as ma
 import scipy.interpolate
-import pkg_resources as pkgr
+import packaging
 
-if pkgr.parse_version(np.__version__)  >= pkgr.parse_version('1.16'):
+if packaging.version.parse(np.__version__)  >= packaging.version.parse('1.16'):
     import numpy.lib.recfunctions as rfn
 
 def resample(data_in, x_in, x_out, y, data_out=None, kind='linear'):
@@ -168,7 +168,7 @@ def resample(data_in, x_in, x_out, y, data_out=None, kind='linear'):
         for i,y in enumerate(y_names):
             y_in[:,i] = data_in[y].filled(np.nan)
     else:
-        if pkgr.parse_version(np.__version__)  >= pkgr.parse_version('1.16'):
+        if packaging.version.parse(np.__version__)  >= packaging.version.parse('1.16'):
             # The slicing does not work in numpy 1.16 and above
             # we use structured_to_unstructured to get the slice that we care about
             y_in = rfn.structured_to_unstructured(

--- a/speclite/utils/package_data.py
+++ b/speclite/utils/package_data.py
@@ -1,13 +1,13 @@
 import os
 
-import pkg_resources
+from importlib import resources
 
 # TODO: should make these Path objects
 
 def get_path_of_data_file(data_file) -> str:
     """convenience wrapper to return location of data file
     """
-    file_path = pkg_resources.resource_filename(
+    file_path = resources.path(
         "speclite", os.path.join("data", f"{data_file}"))
 
     return file_path
@@ -16,6 +16,6 @@ def get_path_of_data_file(data_file) -> str:
 def get_path_of_data_dir() -> str:
     """convenience wrapper to return location of data directory
     """
-    file_path = pkg_resources.resource_filename("speclite", "data")
+    file_path = resources.path("speclite", "data")
 
     return file_path


### PR DESCRIPTION
I'm seeing lots of warnings on import on python 3.9.
This fixes those deprecations