### PR TITLE
Update scipy integration methods in filters.py

### DIFF
--- a/speclite/filters.py
+++ b/speclite/filters.py
@@ -271,13 +271,13 @@ _filter_integration_methods = dict()
 if hasattr(scipy.integrate, "trapezoid"):
     _filter_integration_methods["trapz"] = scipy.integrate.trapezoid
 elif hasattr(scipy.integrate, "trapz"):
-    _filter_integration_methods["trapz"] = scipy.integrate
+    _filter_integration_methods["trapz"] = scipy.integrate.trapz
 else:
     raise RuntimeError("No trapezoidal integration method found in scipy.")
 if hasattr(scipy.integrate, "simpson"):
     _filter_integration_methods["simps"] = scipy.integrate.simpson
 elif hasattr(scipy.integrate, "simps"):
-    _filter_integration_methods["simps"] = scipy.integrate
+    _filter_integration_methods["simps"] = scipy.integrate.simps
 else:
     raise RuntimeError("No Simpson integration method found in scipy.")
 


### PR DESCRIPTION
Newer versions of Scipy have renamed the trapz and simps integration routines to trapezoid and simpson respectively. Currently, importing `speclite.filter` fails with those versions of scipy. Also see [the SciPy issue](https://github.com/scipy/scipy/issues/12924).

This PR will check which variant of those methods is available.